### PR TITLE
Split tuya-convert info into a shared guide and update it

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,9 @@ collections:
   device-standards:
     output: true
     permalink: /standards/:path/
+  shared-guides:
+    output: true
+    permalink: /guides/:path/
 
 defaults:
   -
@@ -45,6 +48,11 @@ defaults:
       path: "_device-standards"
     values:
       layout: "device-standards-index"
+  -
+    scope:
+      path: "_shared-guides"
+    values:
+      layout: "shared-guide"
 
 # Theme Settings
 

--- a/_devices/Lonsonho-9W-E27-RGBWW-bulb.md
+++ b/_devices/Lonsonho-9W-E27-RGBWW-bulb.md
@@ -5,7 +5,7 @@ type: light
 standard: global
 ---
 
-This configuration is for the Lonsonho 9W E27 RGBWW bulb which is offered as a kit of 2 on [aliexpress.com]. The bulb has no special led drivers built in and uses the esp's pulse with modulation for dimming.
+This configuration is for the Lonsonho 9W E27 RGBWW bulb which is offered as a kit of 2 on [aliexpress.com]. The bulb has no special LED drivers built in and uses the ESP's pulse width modulation for dimming.
 
 ## GPIO Pinout
 
@@ -20,50 +20,20 @@ This configuration is for the Lonsonho 9W E27 RGBWW bulb which is offered as a k
 
 ## Getting it up and running
 ### Tuya Convert
+This bulb is a Tuya device, so you'll need to [use tuya-convert to initially get ESPHome onto it](/guides/tuya-convert/).  After that, you can use ESPHome's OTA functionality to make any changes.
 
-- Use tuya convert to initialy flash tasmota without soldering following [this guide]. 
-- At the beginning switch the bulb 4 or 5 times on and off with +- one second delay to enter flashing mode. The bulb blinks rappidly white to confirm flashing mode.
-- During the process don't get nervous, keep calm and be patient.
-- At the end choose to install tasmota firmware.
+- Put the bulb into "smartconfig" / "autoconfig" / pairing mode by switching the bulb off and on 4 or 5 times in a row in quick succession.
+- The bulb blinks white rapidly to confirm that it has entered pairing mode.
 
-Start setting up, creating, compiling and grabbing your own firmware. This is where ESPHome comes in.
-
-**Prerequisit**: ESPHome is installed via Hass.io ADD-ON STORE.
-
-### ESPHome
-- Open ESPHome by choosing it in the left side menu in home assistant.
-- Click in the red plus symbol on the upper right side of the screen.
-- Give a sense-full name. Names must be lowercase and must not contain spaces (allowed characters: a-z, 0-9 and _).
-- Don't bother about the device type, just confirm default selection. This will be adapt later in the code.
-- Enter WiFi SSID, WiFi Password and, if you use, OTA access password.
-- create your device configuration set by clicking in [SUBMIT]
-- Ignore the flashing symbol "Select upload port", just scope on your yaml file and start editing by clicking in "EDIT". If you see a message like "404 file not found", click in another home assistant menu on the left and then back in ESPHome and you'll see the code which you can work with.
-- Scroll down this page to "Basic Configuration", mark and copy the prepared code and paste it into your yaml file. Remember to adapt the following entries:
+Remember to make the following changes to the example YAML config below:
   - line 6: Give your device a name.
   - line 7: Give an ID name, all lower case and change spaces to underscores.
   - line 10: Set up the static ip for your device that matches to your environment. Remember this IP must be unique in your LAN.
   - lines 26, 27 and 28: gateway is the IP of your router, subnet most certainly 255.255.255.0 and dns1 again the IP of your router.
   - line 31: This is only if a red cross appears here. AP SSIDs can only contain up to 32 symbols. If you've chosen a long device name it might exceed. Either shorten the device name or delete right after AP, " (192.168.4.1)".
   - line 32: You'll probably don't want to complicate your live with a WiFi password when your bulb enters access point mode. Feel free to change from password: '1234abcd' to password: ''.
-  - don't forget to hit [SAVE] and [CLOSE]
-- Back in ESPHome dashboard, find your device and check the code by clicking in [VALIDATE]
-- If you've copied and adapted right it will pass validation with success and you can close this dialog. You are now ready to compile your approved firmware.
-- On the top right corner you'll find 3 horizontally stacked points. Click there and chose [Compile]. Give it up to 3 minutes time to do the job the first time until it confirms "INFO Successfully compiled program."
-- On the lower right side, click in [DOWNLOAD BINARY] and store your firmware on your computer where you'll find it later. Don't change the file name.
 
-You're ready to upload your firmware to the bulb. This is where we can say thanks to the amazing feature set of Theo Arends' tasmota firmware which allows to upload and install binary files. This is done only once, after this it'll be much easier uploading newer versions of the firmware over the air directly from ESPHome.
-
-- Your bulb starts providing an open access point with WiFi name tasmota- followed by 4 numbers. Connect to this WiFi and let DHCP provide a suitable IP address on your computer automatically.
-- Open your browser, enter 192.168.4.1 in the address bar and press enter; a captive portal will appear.
-- Enter SSID and WiFi password of your home WiFi and confirm. The bulb will restart and try to access your home WiFi.
-- If the access details where right, your bulb will integrate in your local network. If not, the bulb restarts as access point with captive portal after 1 minute unsuccessful trials. If that is the case, redo the procedure until it's OK.
-- Open your router and seek for the IP address that your router has given with DHCP to your bulb. It should appear in the attached devices named tasmota- followed by 4 numbers.
-- Now open this IP address with your browser, the tasmota dashboard will appear.
-- Click in [Firmware Upgrade], in the following dialog on the lower part in [Browse] and navigate to the binary file you've created and downloaded from ESPHome, then hit [Start upgrade] and wait up to 2 minutes.
-
-Turn back to ESPhome in home assistant and see your bulb coming online with the indicator changing from red Offline to green Online. Any further change to the firmware can now be done, compiled and uploaded over the air directly from here.
-
-You can now integrate your bulb in home assistant using a lovelace light card, just select the good entity.
+Once you've completed the tuya-convert process and flashed ESPHome, you can integrate your bulb in Home Assistant using a lovelace `Light` card.
 
 Enjoy your hard work and impress some people with the magic 8-]
 
@@ -169,4 +139,3 @@ light:
     restore_mode: RESTORE_DEFAULT_ON
 ```
    [aliexpress.com]: <https://www.aliexpress.com/item/33006613923.html>
-   [this guide]: <https://www.digiblur.com/2019/11/tuya-convert-2-flash-tuya-smartlife.html>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -20,6 +20,14 @@
         <a href="{{ standard.url }}" class="navigation-list-link{% if page.url == node.url %} active{% endif %}">{{ standard.title }}</a>
       </li>
     {% endfor %}
+
+    <br>
+    <strong>Shared guides</strong>
+    {% for guide in site.shared-guides | sort: "title" %}
+      <li>
+        <a href="{{ guide.url }}" class="navigation-list-link{% if page.url == node.url %} active{% endif %}">{{ guide.title }}</a>
+      </li>
+    {% endfor %}
     
     <br>
     <strong>External Links</strong>

--- a/_layouts/shared-guide.html
+++ b/_layouts/shared-guide.html
@@ -1,0 +1,9 @@
+---
+layout: default
+---
+
+<h1>{{ page.title }}</h1>
+
+{{ content }}
+
+<a href="https://github.com/jonathanadams/esphome-configs/tree/master/{{ page.relative_path }}">Edit on GitHub</a>

--- a/_shared-guides/tuya-convert.md
+++ b/_shared-guides/tuya-convert.md
@@ -3,6 +3,9 @@ slug: tuya-convert
 title: Prepare a device with tuya-convert
 ---
 
+1. TOC
+{:toc}
+
 ## Introduction
 
 You can use tuya-convert to initially flash a Tuya device, without soldering.  This is especially useful for smart bulbs and other devices which can't readily be opened.
@@ -75,7 +78,7 @@ Now it's time to start setting up, creating, compiling and flashing your own fir
 ## Flashing ESPHome
 Now that you've compiled your ESPHome firmware, you're ready to upload it to your device.  If you chose to flash ESPHome directly using tuya-convert, simply pick your compiled ESPHome firmware during the tuya-convert process, and you're all done!  Otherwise, you'll need to perform an OTA update by following the instructions below.
 
-### Tasmota
+### From Tasmota
 This is where we can say thanks to the amazing feature set of Theo Arends' Tasmota firmware which allows to upload and install binary files. This is done only once; after this it'll be much easier uploading newer versions of the firmware over the air directly from ESPHome.
 
 - Your device will provide an open access point with WiFi name `tasmota`- followed by 4 numbers. Connect to this WiFi and let DHCP provide a suitable IP address on your computer automatically.

--- a/_shared-guides/tuya-convert.md
+++ b/_shared-guides/tuya-convert.md
@@ -1,0 +1,93 @@
+---
+slug: tuya-convert
+title: Prepare a device with tuya-convert
+---
+
+## Introduction
+
+You can use tuya-convert to initially flash a Tuya device, without soldering.  This is especially useful for smart bulbs and other devices which can't readily be opened.
+
+Please read this guide thoroughly before you begin, as there are multiple options available during the process.
+
+Although tuya-convert can be used to flash a precompiled esphome binary directly, it includes a copy of Tasmota, which can be useful to experiment if the configuration for your device is not yet known / available, as it allows you to control pins via the web interface.  Tasmota's OTA process can also be used to flash ESPHome, though if you're using Tasmota 8.x (such as is now included with tuya-convert), [see below for additional instructions](#tasmota-v8x-warning).
+
+## Running tuya-convert
+
+In order to run tuya-convert, you'll need a Linux computer with wifi, plus a second wifi device (such as a smartphone).  This page is not a guide to installing and using tuya-convert in general; if you're not familiar with it, you may find the following helpful:
+- The [tuya-convert documentation](https://github.com/ct-Open-Source/tuya-convert#requirements); or
+- A [video guide to using tuya-convert on a Raspberry Pi](https://www.digiblur.com/2019/11/tuya-convert-2-flash-tuya-smartlife.html)
+
+During the process, don't get nervous - keep calm and be patient.
+
+### Entering Pairing Mode
+In order to put your device into "smartconfig" / "autoconfig" / pairing mode, you can try one of the following:
+- If your device has a button, try holding it for a few seconds
+- If your device is a lightbulb, try switching the bulb on and off 4 or 5 times in quick succession
+
+The device's status LED (or the lightbulb itself) should blink rapidly to confirm that it's in the correct mode.  If this doesn't happen, check your device's manual for any information on entering pairing mode or resetting the device.
+
+### Picking a firmware
+The last step in the tuya-convert process is to choose which firmware to flash.  You have a few options:
+- Install the included Tasmota firmware, bearing in mind that this is now v8.x;
+- Download Tasmota 7.2, place it in the `files` directory within tuya-convert and choose this; or
+- Build ESPHome ([see below](#esphome)) and copy the compiled `firmware.bin` into the `files` directory within tuya-convert and choose this
+
+### Tasmota v8.x Warning
+If you choose to install the included Tasmota (or any other v8.x or later build), you may need to do one of the following in order to flash ESPHome:
+- Downgrade Tasmota to 7.2 (via OTA), then "upgrade" to ESPHome
+- Run `SetOption78 1` in the Tasmota console, reboot/restart your device, then "upgrade" to ESPHome
+  - This option is undocumented, and likely to be removed in some future version of Tasmota
+- Use a version of ESPHome which identifies as "compatible" to Tasmota 8.x
+  - At time of writing, no released ESPHome version (up to 1.14.3) does this
+
+
+## ESPHome
+
+Now it's time to start setting up, creating, compiling and flashing your own firmware. This is where ESPHome comes in.
+
+### If you're using the ESPHome Dashboard (i.e. via the Hass.io add-on)
+- Open ESPHome (in the left side menu in Home Assistant, if you're using the Hass.io addon).
+- Click in the red plus symbol on the upper right side of the screen.
+- Give a sensible name. Names must be lowercase and must not contain spaces (allowed characters: a-z, 0-9 and _).
+- Don't bother about the device type, just confirm default selection. This will be updated later in the code.
+- Enter WiFi SSID, WiFi Password and, if you use one, OTA access password.
+- **Don't forget to enable OTA, or you won't be able to update your device wirelessly**
+- Create your device configuration set by clicking [SUBMIT]
+- Ignore the flashing symbol "Select upload port", just scope on your yaml file and start editing by clicking in "EDIT". If you see a message like "404 file not found", click in another Home Assistant menu on the left and then back in ESPHome and you'll see the code which you can work with.
+- Paste in your YAML configuration, taking care to ensure that details such as the following are correct:
+  - Device name
+  - WiFi credentials (SSID and password)
+  - Static IP address, if required
+  - OTA enabled (and correct/expected password)
+  - Don't forget to hit [SAVE] and [CLOSE]
+- Back in the ESPHome dashboard, find your device and check the code by clicking [VALIDATE]
+- If you've copied and adapted right it will pass validation with success and you can close this dialog. You are now ready to compile your approved firmware.
+- On the top right corner you'll find 3 horizontally stacked points. Click there and chose [Compile]. Give it up to 3 minutes time to do the job the first time until it confirms "INFO Successfully compiled program."
+- On the lower right side, click [DOWNLOAD BINARY] and store your firmware on your computer where you'll find it later. Don't change the file name.
+
+### If you're using the ESPHome Command-Line Interface (CLI)
+- Build your YAML file as above, taking care to set details such as the device name, WiFi and OTA details correctly
+- **Don't forget to include the OTA config, or you won't be able to update your device wirelessly**
+- Run `esphome your_device.yaml compile` (replacing `your_device.yaml` with the actual file name)
+- Once it's finished, find the compiled firmware (i.e. `your_device/.pioenvs/your_device/firmware.bin`)
+
+
+## Flashing ESPHome
+Now that you've compiled your ESPHome firmware, you're ready to upload it to your device.  If you chose to flash ESPHome directly using tuya-convert, simply pick your compiled ESPHome firmware during the tuya-convert process, and you're all done!  Otherwise, you'll need to perform an OTA update by following the instructions below.
+
+### Tasmota
+This is where we can say thanks to the amazing feature set of Theo Arends' Tasmota firmware which allows to upload and install binary files. This is done only once; after this it'll be much easier uploading newer versions of the firmware over the air directly from ESPHome.
+
+- Your device will provide an open access point with WiFi name `tasmota`- followed by 4 numbers. Connect to this WiFi and let DHCP provide a suitable IP address on your computer automatically.
+- Open your browser, enter 192.168.4.1 in the address bar and press enter; a captive portal will appear.
+- Enter SSID and WiFi password of your home WiFi and confirm. The bulb will restart and try to access your home WiFi.
+- If the access details were right, your bulb will connect to your local network. If not, the bulb restarts as an access point with captive portal after 1 minute of unsuccessful connection attempts. If that is the case, redo the procedure until it's OK.
+- Reconnect your computer to your regular WiFi network, if it doesn't automatically do this.
+- Open your router and seek for the IP address that your router has given with DHCP to your bulb. It should appear in the attached devices named `tasmota-` followed by 4 numbers (the same as the network you connected to in order to set your WiFi details).
+- Now open this IP address with your browser, the Tasmota dashboard will appear.
+- If you installed Tasmota 8.x, see the [Tasmota 8.x Warning](#tasmota-v8x-warning) above.
+- Click [Firmware Upgrade], in the following dialog on the lower part click [Browse] and navigate to the binary file you downloaded or compiled above, then hit [Start upgrade] and wait up to 2 minutes.
+
+Upon returning to the ESPhome dashboard (if you're using it), you should see your device coming online with the indicator changing from red Offline to green Online. Any further changes to the firmware can now be done, compiled and uploaded over the air directly from here.
+
+Your device should now be available to integrate with Home Assistant - enjoy!


### PR DESCRIPTION
Splits the tuya-convert guide out from the `Lonsonho 9W E27 RGBWW bulb` page and updates it to:
- Make it more generic / device-agnostic, so that other Tuya devices can refer to it
- Cover how to work around Tasmota 8.x's firmware "compatibility" checks, as tuya-convert now includes v8.1.0.2
- Add information for people who aren't using the ESPHome Dashboard
- General updates, tweaks and tidying up

I've added a new "Shared guides" section to the menu with a direct link to the guide, as I think it might be useful for anyone else who acquires a new Tuya device (i.e. one which doesn't yet have a configuration published on the site) to help them get started.