### PR TITLE
add editorconfig to welcome contributors with the correct whitespace …

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
…settings, etc

hey :) awesome effort here - this is a thing that esphome itself is truly missing!
do  you know [editorconfig](https://editorconfig.org/)? Can you please add this .editorconfig file to the project?