### PR TITLE
Update BlitzWolf-BW-SHP2-Power-Monitoring-Plug.md

### DIFF
--- a/_devices/BlitzWolf-BW-SHP2-Power-Monitoring-Plug/BlitzWolf-BW-SHP2-Power-Monitoring-Plug.md
+++ b/_devices/BlitzWolf-BW-SHP2-Power-Monitoring-Plug/BlitzWolf-BW-SHP2-Power-Monitoring-Plug.md
@@ -109,7 +109,7 @@ sensor:
       number: GPIO12
       inverted: true
     cf_pin: GPIO05
-    cf1_pin: GPIO15
+    cf1_pin: GPIO14
     change_mode_every: 8
     update_interval: 10s
     current:


### PR DESCRIPTION
GPIO Pinout of Base Hardware says GPIO14 = HLWBL CF1 Pin But Yaml it is written as cf1_pin: GPIO15
Hence changing cf1_pin: GPIO15 to cf1_pin: GPIO14 in yaml.
Verified the same in my blitzwolf module & Found to be OK
Please approve