### PR TITLE
Add Shelly i3 config

### DIFF
--- a/_devices/Shelly-i3/Shelly-i3.md
+++ b/_devices/Shelly-i3/Shelly-i3.md
@@ -1,0 +1,68 @@
+---
+title: Shelly i3
+date-published: 2020-09-24
+type: switch
+standard: uk, us, eu
+---
+
+1. TOC
+   {:toc}
+
+## GPIO Pinout
+
+| Pin    | Function |
+| ------ | -------- |
+| GPIO12 | Relay    |
+| GPIO13 | Relay    |
+| GPIO14 | Relay    |
+
+## Basic Configuration
+
+Since the Shelly i3 has floating inputs there needs to be a delayed_on_off present. 50ms should be sufficient.
+
+```yaml
+# Basic Config
+substitutions:
+  devicename: shelly_25
+
+esphome:
+  name: ${devicename}
+  platform: ESP8266
+  board: esp01_1m
+
+wifi:
+  ssid: !secret ssid1
+  password: !secret ssid1_pass
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+
+ota:
+
+# Device Specific Config
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO12
+      mode: INPUT
+    name: ${devicename} Switch 1
+    filters:
+      - delayed_on_off: 50ms
+  - platform: gpio
+    pin:
+      number: GPIO13
+      mode: INPUT
+    name: ${devicename} Switch 2
+    filters:
+      - delayed_on_off: 50ms
+  - platform: gpio
+    pin:
+      number: GPIO14
+      mode: INPUT
+    name: ${devicename} Switch 3
+    filters:
+      - delayed_on_off: 50ms
+```

--- a/_devices/Shelly-i3/Shelly-i3.md
+++ b/_devices/Shelly-i3/Shelly-i3.md
@@ -23,7 +23,7 @@ Since the Shelly i3 has floating inputs there needs to be a delayed_on_off prese
 ```yaml
 # Basic Config
 substitutions:
-  devicename: shelly_25
+  devicename: shelly_i3
 
 esphome:
   name: ${devicename}


### PR DESCRIPTION
This adds a Shelly i3 config. I verified it on my own i3 and it's working fine. There needs to be a `delayed_on_off` present because of the floating inputs.