### PR TITLE
Update Sonoff-Mini-Relay.md

### DIFF
--- a/_devices/Sonoff-Mini-Relay/Sonoff-Mini-Relay.md
+++ b/_devices/Sonoff-Mini-Relay/Sonoff-Mini-Relay.md
@@ -66,7 +66,7 @@ binary_sensor:
 
   - platform: gpio
     name: ${device_name}_status
-    pin: 
+    pin:
       number: GPIO04
       mode: INPUT_PULLUP
       inverted: True

--- a/_devices/Sonoff-Mini-Relay/Sonoff-Mini-Relay.md
+++ b/_devices/Sonoff-Mini-Relay/Sonoff-Mini-Relay.md
@@ -66,7 +66,10 @@ binary_sensor:
 
   - platform: gpio
     name: ${device_name}_status
-    pin: GPIO04
+    pin: 
+      number: GPIO04
+      mode: INPUT_PULLUP
+      inverted: True
     id: switch_1
     on_press:
       then:


### PR DESCRIPTION
See https://tasmota.github.io/docs/devices/Sonoff-Mini/ GPIO4 is high using PULLUP and upon SW press, goes LOW/GND