### PR TITLE
Update custom component URL on Arlec Grid Connect Smart LED Globe Page

### DIFF
--- a/_devices/Arlec-Grid-Connect-Smart-LED-Globe-CWWW/Arlec-Grid-Connect-Smart-LED-Globe-CWWW.md
+++ b/_devices/Arlec-Grid-Connect-Smart-LED-Globe-CWWW/Arlec-Grid-Connect-Smart-LED-Globe-CWWW.md
@@ -10,4 +10,4 @@ As per the [Arlec Grid Connect Smart LED Globe RGB](https://esphome-configs.io/d
 However unlike the RGB version these appear to use a BP5926 chip to drive the LED's and this chip uses a PWM signal so set the colour temperature rather than a PWM signal for each colour channel.
 
 To get these globes to work I needed to write a Custom Light Component in ESPHome due to the BP5926 chip that they have used to drive the LED's.
-The custom component is available at <https://github.com/cdmonk/esphome_ArlecSmartGlobe.>
+The custom component is available at <https://github.com/cdmonk/esphome_ArlecSmartGlobe>.


### PR DESCRIPTION
Updates the custom component URL on [Arlec Grid Connect Smart LED Globe CWWW page](https://esphome-configs.io/devices/arlec-grid-connect-smart-led-globe-cwww/) from https://github.com/cdmonk/esphome_ArlecSmartGlobe. to https://github.com/cdmonk/esphome_ArlecSmartGlobe so that the URL is no longer a 404.