### PR TITLE
Update Status LED URL on the Sonoff 4CH Pro R2 page

### DIFF
--- a/_devices/Sonoff-4CH-Pro-R2/Sonoff-4CH-Pro-R2.md
+++ b/_devices/Sonoff-4CH-Pro-R2/Sonoff-4CH-Pro-R2.md
@@ -120,7 +120,7 @@ switch:
 
 Use *one* of the following three configurations to adjust the led to your needs.
 
-### Status LED (see <https://esphome.io/components/status_led.html)>
+### Status LED (see <https://esphome.io/components/status_led.html>)
 
 ```yaml
 status_led:


### PR DESCRIPTION
Update Status LED URL on the Sonoff 4CH Pro R2 page from "https://esphome.io/components/status_led.html)" to "https://esphome.io/components/status_led.html" as the ")" made it a 404.