### PR TITLE
Fix typo in Shelly Plug S example configuration

### DIFF
--- a/_devices/Shelly-Plug-S/Shelly-Plug-S.md
+++ b/_devices/Shelly-Plug-S/Shelly-Plug-S.md
@@ -177,7 +177,7 @@ sensor:
       icon: mdi:flash-outline
     power:
       name: "${channel_1} power"
-      id: vermogen
+      id: power
       unit_of_measurement: "W"
       icon: mdi:flash-outline
       on_value_range:


### PR DESCRIPTION
Use `power` as the `id` instead of  `vermogen` to fix the reference used in `total_daily_energy` sensor.