### PR TITLE
Avoid flooding Home Assistant with updates from s31 power sensors

### DIFF
--- a/_devices/Sonoff-S31/Sonoff-S31.md
+++ b/_devices/Sonoff-S31/Sonoff-S31.md
@@ -60,10 +60,13 @@ sensor:
   - platform: cse7766
     current:
       name: "Sonoff S31 Current"
+      accuracy_decimals: 1
     voltage:
       name: "Sonoff S31 Voltage"
+      accuracy_decimals: 1
     power:
       name: "Sonoff S31 Power"
+      accuracy_decimals: 1
 switch:
   - platform: gpio
     name: "Sonoff S31 Relay"


### PR DESCRIPTION
The power sensors could not provide reliable data with more than 1 decimal place, and would flood Home Assistant with state change events when there are 10s of these devices.